### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Context Protocol (MCP).
 Everything from user registration and authentication to interacting with user
 data is handled via MCP tools.
 
+<a href="https://glama.ai/mcp/servers/@epicweb-dev/epic-me-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@epicweb-dev/epic-me-mcp/badge" alt="EpicMe MCP server" />
+</a>
+
 The goal is to demonstrate a possible future of applications where users
 interact with our apps via natural language with LLMs and the MCP protocol. This
 will also be the basis upon which I will teach how to build MCP tools on


### PR DESCRIPTION
This PR adds a badge for the [EpicMe MCP](https://glama.ai/mcp/servers/@epicweb-dev/epic-me-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@epicweb-dev/epic-me-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@epicweb-dev/epic-me-mcp/badge" alt="EpicMe MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.